### PR TITLE
Add tracker and TURN relay

### DIFF
--- a/addons/tube/tube_client.gd
+++ b/addons/tube/tube_client.gd
@@ -630,6 +630,7 @@ func _initiate_peer(p_peer_id: int) -> TubePeer:
 	var peer := TubePeer.new(p_peer_id)
 	peer.signaling_timeout_time = peer_signaling_timeout
 	peer.signaling_max_attempts = peer_signaling_max_attempts
+	
 	var error := peer.initialize(
 		context.get_ice_servers()
 	)

--- a/addons/tube/tube_tracker.gd
+++ b/addons/tube/tube_tracker.gd
@@ -182,6 +182,8 @@ func send_stop(p_info_hash: String, p_peer_id_hash: String) -> Error:
 
 
 func _received_packet(p_packet: PackedByteArray):
+
+
 	var data = decode_packet(p_packet)
 	if not data is Dictionary:
 		raise_warning("Received invalid packet: {packet}".format({

--- a/scenes/ui/main_menu.gd
+++ b/scenes/ui/main_menu.gd
@@ -8,6 +8,7 @@ extends CanvasLayer
 @onready var button_join_tube: Button = %ButtonJoinTube
 @onready var button_quit_tube: Button = %ButtonQuitTube
 @onready var button_create_tube: Button = %ButtonCreateTube
+@onready var toggle_turn: CheckButton = %ToggleTurn
 
 @onready var enet_menu: VBoxContainer = %EnetMenu
 @onready var tube_menu: VBoxContainer = %TubeMenu
@@ -33,6 +34,9 @@ func _ready() -> void:
 	
 	Network.tube_client.error_raised.connect(on_error_raised)
 
+	toggle_turn.set_pressed(Network.turn_enabled)
+	toggle_turn.toggled.connect(func(new_value): Network.turn_enabled = new_value)
+
 	if OS.has_feature('server'):
 		Network.start_server()
 		await get_tree().create_timer(0.1).timeout
@@ -56,8 +60,11 @@ func on_create_tube():
 	add_world()
 
 func update_session(new_text: String):
-	if new_text != '':
-		button_join_tube.disabled = false
+	button_join_tube.disabled = new_text ==  ""
+	var caret_pos: int = line_edit_session.caret_column
+	line_edit_session.text = new_text.to_upper()
+	line_edit_session.caret_column = caret_pos
+
 
 func update_username(new_text: String):
 	Global.username = new_text

--- a/scenes/ui/main_menu.tscn
+++ b/scenes/ui/main_menu.tscn
@@ -66,14 +66,6 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 24
 text = "Androo Game"
 
-[node name="LabelSessionid" type="Label" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=390504241]
-layout_mode = 2
-text = "Session ID:"
-
-[node name="LineEditSession" type="LineEdit" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=382891492]
-unique_name_in_owner = true
-layout_mode = 2
-
 [node name="LabelUsername" type="Label" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=1449943180]
 layout_mode = 2
 text = "Username:"
@@ -82,6 +74,14 @@ text = "Username:"
 unique_name_in_owner = true
 layout_mode = 2
 max_length = 12
+
+[node name="LabelSessionid" type="Label" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=390504241]
+layout_mode = 2
+text = "Session ID:"
+
+[node name="LineEditSession" type="LineEdit" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=382891492]
+unique_name_in_owner = true
+layout_mode = 2
 
 [node name="HSeparator" type="HSeparator" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=814587652]
 layout_mode = 2
@@ -107,3 +107,16 @@ layout_mode = 2
 theme_override_constants/icon_max_width = 24
 text = "Create Session"
 icon = ExtResource("2_fe2o3")
+
+[node name="HSeparator3" type="HSeparator" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=884198939]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="ToggleTurn" type="CheckButton" parent="Control/Center/MarginContainer/HBoxContainer/TubeMenu" unique_id=1870884571]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Enable if having trouble connecting on a
+restrictive network like a VPN or university"
+mouse_default_cursor_shape = 2
+theme_override_font_sizes/font_size = 14
+text = "TURN Relay:"

--- a/scenes/ui/main_menu.tscn
+++ b/scenes/ui/main_menu.tscn
@@ -116,7 +116,8 @@ theme_override_constants/separation = 8
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Enable if having trouble connecting on a
-restrictive network like a VPN or university"
+restrictive network like a VPN or university. 
+The host and joiners will all need to have it on."
 mouse_default_cursor_shape = 2
 theme_override_font_sizes/font_size = 14
 text = "TURN Relay:"

--- a/scripts/network.gd
+++ b/scripts/network.gd
@@ -5,15 +5,23 @@ const TUBE_CONTEXT = preload("uid://chqw3jdoon6c1")
 
 var enet_peer := ENetMultiplayerPeer.new()
 var tube_client := TubeClient.new()
-var tube_enabled = true
+var tube_enabled := true
+var turn_enabled := false : set = set_turn_enabled
+
+var new_offline := OfflineMultiplayerPeer.new()
+var new_http_client := HTTPRequest.new()
 
 var PORT = 9999
 var IP_ADDRESS = '127.0.0.1'
 
 func _ready() -> void:
+	new_http_client.request_completed.connect(_on_request_completed)
+	get_tree().root.add_child.call_deferred(new_http_client)
+
 	if tube_enabled:
 		tube_client.context = TUBE_CONTEXT
 		get_tree().root.add_child.call_deferred(tube_client)
+
 
 func tube_create():
 	multiplayer.peer_connected.connect(add_player)
@@ -83,3 +91,21 @@ func clean_up_signals():
 func _exit_tree() -> void:
 	if tube_enabled:
 		tube_client.leave_session()
+
+var temp_ice: Dictionary
+
+func _on_request_completed(_result, _response_code, _headers, body):
+	var response: Dictionary = JSON.parse_string(body.get_string_from_utf8())
+
+	if response and response.has("iceServers"):
+		temp_ice = response["iceServers"][1]
+		tube_client.context.turn_servers.append(temp_ice)
+		prints("DEBUG", tube_client.context.turn_servers)
+
+func set_turn_enabled(is_enabled: bool):
+	if is_enabled and temp_ice:
+		tube_client.context.turn_servers.append(temp_ice)
+	elif is_enabled:
+		new_http_client.request("https://api.androodev.com/turn")
+	else:
+		tube_client.context.turn_servers = []

--- a/scripts/tube_context.tres
+++ b/scripts/tube_context.tres
@@ -5,6 +5,6 @@
 [resource]
 script = ExtResource("1_joa4x")
 app_id = "HUU9+)rs-yUMUnm"
-trackers_urls = Array[String](["wss://tracker.openwebtorrent.com", "wss://tracker.files.fm:7073/announce", "wss://tracker.btorrent.xyz/"])
-stun_servers_urls = Array[String](["stun:stun.l.google.com:19302", "stun:stun.cloudflare.com:3478", "stun:stun.bethesda.net:3478"])
+trackers_urls = Array[String](["wss://tracker.androodev.com"])
+stun_servers_urls = Array[String](["stun:stun.l.google.com:19302", "stun:stun.cloudflare.com:3478"])
 metadata/_custom_type_script = "uid://t4pe7yqc3pnt"

--- a/scripts/tube_context.tres
+++ b/scripts/tube_context.tres
@@ -5,6 +5,7 @@
 [resource]
 script = ExtResource("1_joa4x")
 app_id = "HUU9+)rs-yUMUnm"
+session_id_characters_set = "ABCDEFGHIJKLMNPQRSTUVWXYZ123456789"
 trackers_urls = Array[String](["wss://tracker.androodev.com"])
 stun_servers_urls = Array[String](["stun:stun.l.google.com:19302", "stun:stun.cloudflare.com:3478"])
 metadata/_custom_type_script = "uid://t4pe7yqc3pnt"


### PR DESCRIPTION
- This PR adds a new tracker: `wss://tracker.androodev.com`. This should be slightly more reliable than the others. 
- This PR adds a TURN server toggle for relay backup. It's toggled off by default. Flipping the toggle makes a call to the API to get the TURN credentials to use from Cloudflare. This should help people on more restrictive connections like VPNs or on university campus network (Note: This may change if usage gets super high, I may have restrict it in the future)

The tracker service is: https://github.com/jonandrewdavis/ws-tracker-server
The turn service is: https://github.com/jonandrewdavis/ws-tracker-api that just requests it from Cloudflare


Also prevents fetching multiple times when on / off by using a temp var 


https://github.com/user-attachments/assets/0a7da19e-e578-4eb8-8247-a10478e950d6


